### PR TITLE
Fix: Auto aria-levels (Issue #38)

### DIFF
--- a/templates/list.jsx
+++ b/templates/list.jsx
@@ -8,7 +8,7 @@ export default function List({ _columns, _orderedList, _items, ...props }) {
   const {
     _ariaLevel
   } = props;
-  const itemAriaLevel = _.isNumber(_ariaLevel) && _ariaLevel !== 0 : _ariaLevel;
+  const itemAriaLevel = _.isNumber(_ariaLevel) && _ariaLevel !== 0 ? _ariaLevel + 1 : _ariaLevel;
   return (
     <div className="component__inner list__inner">
       <templates.header {...props} />

--- a/templates/list.jsx
+++ b/templates/list.jsx
@@ -8,8 +8,7 @@ export default function List({ _columns, _orderedList, _items, ...props }) {
   const {
     _ariaLevel
   } = props;
-  const itemAriaLevel = _.isNumber(_ariaLevel) ? _ariaLevel + 1 : _ariaLevel;
-
+  const itemAriaLevel = _.isNumber(_ariaLevel) && _ariaLevel !== 0 : _ariaLevel;
   return (
     <div className="component__inner list__inner">
       <templates.header {...props} />


### PR DESCRIPTION
Fixes issue #38. 

Only likely to occur when courses are exported from the Adapt Authoring tool. 

Occurs when _ariaLevel exists and its assigned the default value. Affects subheadings in component (when override exists and set to 0(zero)