### PR TITLE
Fix: animate items in from the right for RTL languages (fixes #41)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
         "url": "git://github.com/cgkineo/adapt-list.git"
     },
     "framework": ">=5.14",
-    "version": "5.1.0",
+    "version": "5.1.1",
     "homepage": "https://github.com/cgkineo/adapt-list",
     "issues": "https://github.com/cgkineo/adapt-list/issues",
     "component": "list",

--- a/less/list.less
+++ b/less/list.less
@@ -49,10 +49,20 @@
     right: -100%;
     opacity: 0;
     .transition(all .8s ease-in-out);
+    
+    .dir-rtl & {
+      right: inherit;
+      left: -100%;
+    }
 
     &.is-animating {
       right: 0;
       opacity: 1;
+      
+      .dir-rtl & {
+        right: inherit;
+        left: 0;
+      }
     }
   }
 


### PR DESCRIPTION
fixes https://github.com/cgkineo/adapt-list/issues/41

Prevents items overlapping each other as they transition in when `_columns` is enabled. 