### PR TITLE
Fix: don't animate when Visua11y _noAnimations is enabled (fixes #44)

### DIFF
--- a/js/list-view.js
+++ b/js/list-view.js
@@ -4,8 +4,8 @@ class ListView extends ComponentView {
 
   className() {
     let classes = super.className();
-
-    if (this.model.get('_animateList')) {
+    // don't animate when Visua11y 'no animations' is set
+    if (this.model.get('_animateList') && (!$('html').hasClass('a11y-no-animations'))) {
       classes += ' is-animated-list';
     }
 
@@ -16,7 +16,7 @@ class ListView extends ComponentView {
     this.setReadyStatus();
     this.setupInviewCompletion('.component__widget');
 
-    if (this.model.get('_animateList')) {
+    if (this.model.get('_animateList') && (!$('html').hasClass('a11y-no-animations'))) {
       this.$('.list__container').on('onscreen.animate', this.checkIfOnScreen.bind(this));
     }
   }


### PR DESCRIPTION
List items shouldn't animate on screen when Visua11y [_noAnimations](https://github.com/cgkineo/adapt-visua11y/blob/db8cfc126f8b01f9c6d72ea34aa73832addcb877/example.json#L55) is enabled.

Instead, list items should display as standard (as if `"_animateList": false` was set).

Fixes https://github.com/cgkineo/adapt-list/issues/44