### PR TITLE
Fix: Review default styling and modernise (fixes #46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This defines the horizontal position of the component in the block. Acceptable v
 Defines the number of columns wide the **\_items** are displayed in. If the value of **\_numberOfColumns** is `2`, each **\_items** will be 50% wide. Similarly, if the value of **\_numberOfColumns** is `3`, each **\_items** will be 33.3% wide. In mobile view, the width of each **\_items** is 100%.
 
 ### \_orderedList (boolean):
-If set to `true`, each item in the list will numbered. This setting will only take affect if there are no list item images defined. The default value is `false`.
+If set to `true`, each item in the list will be numbered. This setting will only take affect if there are no list item images defined. The default value is `false`.
 
 ### \_animateList (boolean):
 If set to `true`, the list of items will animate when scrolled into view. The default value is `false`.
@@ -41,7 +41,7 @@ Controls the horizontal alignment of the list items. This setting will only take
 * `end`: Aligns the list item to the opposite side of the natural page direction. In a left-to-right course this is right by default.
 
 ### \_bulletAlignment (string):
-Controls the vertical alignment of the list item image or bullet alongside the text content. If the `_columns` property has a value above `0` then this properties alignment switches from vertical to horizontal. Values available utilise the CSS property [`align-items`](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items). The default value is `start`. It contains the following settings:
+Controls the vertical alignment of the list item image or bullet alongside the text content. If the `_columns` property has a value above `0` then the alignment switches from vertical to horizontal. Values available utilise the CSS property [`align-items`](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items). The default value is `start`. It contains the following settings:
 * `start`: Aligns the list item image or bullet to the top of the container. If `_columns` is used then this setting aligns the list item image or bullet with the natural page direction. In a left-to-right course this is left by default.
 * `center`: Aligns the list item image or bullet to the center of the container vertically. If `_columns` is used then this setting aligns the list item image or bullet horizontally.
 * `end`: Aligns the list item image or bullet to the bottom of the container. If `_columns` is used then this setting aligns the list item image or bullet to the opposite side of the natural page direction. In a left-to-right course this is right by default.
@@ -52,7 +52,8 @@ Multiple items may be created. Each item represents one list item for this compo
 #### title (string):
 This is the title text for the list item.
 
-#### body (string): This is the main body text for the list item.
+#### body (string):
+This is the main body text for the list item.
 
 #### \_graphic (object):
 The graphic object that defines the image which is rendered alongside the body text. It contains the following settings:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Controls the horizontal alignment of the list items. This setting will only take
 ### \_bulletAlignment (string):
 Controls the vertical alignment of the list item image or bullet alongside the text content. If the `_columns` property has a value above `0` then this properties alignment switches from vertical to horizontal. Values available utilise the CSS property [`align-items`](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items). The default value is `start`. It contains the following settings:
 * `start`: Aligns the list item image or bullet to the top of the container. If `_columns` is used then this setting aligns the list item image or bullet with the natural page direction. In a left-to-right course this is left by default.
-* `center`: Aligns the list item image or bullet to the center of the container vertically. If `_columns` is used then this settings aligns the list item image or bullet horizontally.
+* `center`: Aligns the list item image or bullet to the center of the container vertically. If `_columns` is used then this setting aligns the list item image or bullet horizontally.
 * `end`: Aligns the list item image or bullet to the bottom of the container. If `_columns` is used then this setting aligns the list item image or bullet to the opposite side of the natural page direction. In a left-to-right course this is right by default.
 
 ### \_items (object):

--- a/README.md
+++ b/README.md
@@ -29,15 +29,11 @@ If set to `true`, the list of items will animate when scrolled into view. The de
 ### \_percentInviewVertical (number):
 Controls what percentage of the list items height needs to be in the viewport in order for the items to animate. Default value is to animate when 70% 'in view'. You only need to set this property if you want to override the default value.
 
-<a name="_itemHorizontalAlignment"></a>
-
 ### \_itemHorizontalAlignment (string):
 Controls the horizontal alignment of the list items. This setting will only take affect if the `_columns` property has a value above `0`. Values available utilise the CSS property [`justify-content`](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content). The default value is `start`. It contains the following settings:
 * `start`: Aligns the list item with the natural page direction. In a left-to-right course this is left by default.
 * `center`: Aligns the list item to the center of the container.
 * `end`: Aligns the list item to the opposite side of the natural page direction. In a left-to-right course this is right by default.
-
-<a name="_bulletAlignment"></a>
 
 ### \_bulletAlignment (string):
 Controls the vertical alignment of the list item image or bullet alongside the text content. If the `_columns` property has a value above `0` then this properties alignment switches from vertical to horizontal. Values available utilise the CSS property [`align-items`](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items). The default value is `start`. It contains the following settings:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 **List** is a *presentation component* which displays text in a list. The list items can be displayed with or without an image. If no image is defined then either a plain bullet (unordered) or numerical bullet that counts upwards per item (ordered) will display.
 
-<img src="demo.gif" alt="the list component in action" align="right">
+## Support layouts
+
+Layout | Image | Layout | Image
+--- | --- | --- | ---
+Images (maximum width of 64px) | <img width="450" alt="Screenshot 2022-12-02 at 11 59 53" src="https://user-images.githubusercontent.com/11569678/205288598-55092153-fcbf-40ec-9801-e81d0bb055fe.png"> | Unordered and ordered lists | <img width="450" alt="Screenshot 2022-12-02 at 12 00 27" src="https://user-images.githubusercontent.com/11569678/205288646-0d5050ce-6bd1-4ab3-9779-f0d15620e92c.png">
+Columns with images | <img width="450" alt="Screenshot 2022-12-02 at 12 01 08" src="https://user-images.githubusercontent.com/11569678/205288664-c060d166-e155-44fd-9630-0888f70a1431.png"> | Columns with unordered and ordered lists | <img width="450" alt="Screenshot 2022-12-02 at 12 01 41" src="https://user-images.githubusercontent.com/11569678/205288683-fd1faf84-0266-4db0-a681-9016e0f0c049.png">
 
 ## Attributes
 

--- a/README.md
+++ b/README.md
@@ -1,47 +1,78 @@
 # adapt-list
 
-**List** is a *presentation component* which displays text in a list. Text can be in an ordered, or unordered, list with or without an image.
+**List** is a *presentation component* which displays text in a list. The list items can be displayed with or without an image. If no image is defined then either a plain bullet (unordered) or numerical bullet that counts upwards per item (ordered) will display.
 
 <img src="demo.gif" alt="the list component in action" align="right">
 
-### Attributes
+## Attributes
 
 [**core model attributes**](https://github.com/adaptlearning/adapt_framework/wiki/Core-model-attributes): These are inherited by every Adapt component. [Read more](https://github.com/adaptlearning/adapt_framework/wiki/Core-model-attributes).
 
-**\_component** (string): This value must be: `text`.
+### \_component (string):
+This must be set to: `"list"`.
 
-**\_classes** (string): CSS class name to be applied to **List**’s containing `div`. The class must be predefined in one of the Less files. Separate multiple classes with a space. Supported classes are `"align-items-vert-center"` which aligns either the step number or image centrally, on the vertical axis, with the content.
+### \_classes (string):
+CSS class name(s) to be applied to this component's containing `div`. The class must be predefined in one of the Less files. Separate multiple classes with a space.
 
-**\_layout** (string): This defines the horizontal position of the component in the block. Acceptable values are `full`, `left` or `right`.
+### \_layout (string):
+This defines the horizontal position of the component in the block. Acceptable values are `full`, `left` or `right`.
 
-**\_animateList** (boolean): If set to `true`, the list of items will animate when scrolled into view. The default value is `false`.
+### \_columns (number):
+Defines the number of columns wide the **\_items** are displayed in. If the value of **\_numberOfColumns** is `2`, each **\_items** will be 50% wide. Similarly, if the value of **\_numberOfColumns** is `3`, each **\_items** will be 33.3% wide. In mobile view, the width of each **\_items** is 100%.
 
-**\_percentInviewVertical** (number): Controls what percentage of the list items height needs to be in the viewport in order for the items to animate. Default value is to animate when 70% 'in view'. You only need to set this property if you want to override the default value.
+### \_orderedList (boolean):
+If set to `true`, each item in the list will numbered. This setting will only take affect if there are no list item images defined. The default value is `false`.
 
-**\_orderedList** (boolean): If set to `true`, each item in the list will numbered. The default value is `false`.
+### \_animateList (boolean):
+If set to `true`, the list of items will animate when scrolled into view. The default value is `false`.
 
-**\_columns** (number): Defines the number of columns wide the **\_items** are displayed in. If the value of **\_numberOfColumns** is `2`, each **\_items** will be 50% wide. Similarly, if the value of **\_numberOfColumns** is `3`, each **\_items** will be 33.3% wide. In tablet view, the width of each **\_items** is 50%. In mobile view, the width of each **\_items** is 100%.
+### \_percentInviewVertical (number):
+Controls what percentage of the list items height needs to be in the viewport in order for the items to animate. Default value is to animate when 70% 'in view'. You only need to set this property if you want to override the default value.
 
-**\_items** (string): Multiple items may be created. Each item represents one list item for this component and contains values for **title**, **body**, **\_imageSrc**, **alt** and **_classes**.
+<a name="_itemHorizontalAlignment"></a>
 
->**title** (string): This is the title text for the list item.
+### \_itemHorizontalAlignment (string):
+Controls the horizontal alignment of the list items. This setting will only take affect if the `_columns` property has a value above `0`. Values available utilise the CSS property [`justify-content`](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content). The default value is `start`. It contains the following settings:
+* `start`: Aligns the list item with the natural page direction. In a left-to-right course this is left by default.
+* `center`: Aligns the list item to the center of the container.
+* `end`: Aligns the list item to the opposite side of the natural page direction. In a left-to-right course this is right by default.
 
->**body** (string): This is the main body text for the list item.
+<a name="_bulletAlignment"></a>
 
->**\_imageSrc** (string):  File name (including path) of the image. Path should be relative to the *src* folder (e.g., *course/en/images/origami-menu-two.jpg*). Only supported when **\_orderedList** is set to `false`.
+### \_bulletAlignment (string):
+Controls the vertical alignment of the list item image or bullet alongside the text content. If the `_columns` property has a value above `0` then this properties alignment switches from vertical to horizontal. Values available utilise the CSS property [`align-items`](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items). The default value is `start`. It contains the following settings:
+* `start`: Aligns the list item image or bullet to the top of the container. If `_columns` is used then this setting aligns the list item image or bullet with the natural page direction. In a left-to-right course this is left by default.
+* `center`: Aligns the list item image or bullet to the center of the container vertically. If `_columns` is used then this settings aligns the list item image or bullet horizontally.
+* `end`: Aligns the list item image or bullet to the bottom of the container. If `_columns` is used then this setting aligns the list item image or bullet to the opposite side of the natural page direction. In a left-to-right course this is right by default.
 
->**alt** (string): The alternative text for the item image. Assign [alt text](https://github.com/adaptlearning/adapt_framework/wiki/Providing-good-alt-text) to images that convey course content only.
+### \_items (object):
+Multiple items may be created. Each item represents one list item for this component. It contains the following settings:
 
->**\_classes** (string): CSS class name to be applied to list item. The class must be predefined in one of the Less files. Separate multiple classes with a space.
+#### title (string):
+This is the title text for the list item.
+
+#### body (string): This is the main body text for the list item.
+
+#### \_graphic (object):
+The graphic object that defines the image which is rendered alongside the body text. It contains the following settings:
+
+##### src (string):
+File name (including path) of the image. Path should be relative to the `src` folder (e.g. `"course/en/images/origami-menu-two.jpg"`). Only supported when **\_orderedList** is set to `false`.
+
+##### alt (string):
+The alternative text for this image. Assign [alt text](https://github.com/adaptlearning/adapt_framework/wiki/Providing-good-alt-text) to images that convey course content only.
+
+##### attribution (string):
+Optional text to be displayed as an [attribution](https://wiki.creativecommons.org/Best_practices_for_attribution). By default it is displayed below the image. Adjust positioning by modifying CSS. Text can contain HTML tags, e.g., `Copyright © 2015 by <b>Lukasz 'Severiaan' Grela</b>`
 
 ## Limitations
 
 No known limitations.
 
 ----------------------------
-**Version number:**  5.0.0  
-**Framework versions:** 5.14+  
-**Author / maintainer:** Kineo  
-**Accessibility support:** WAI AA  
-**RTL support:** Yes  
-**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, IE11, Safari 14 for macOS/iOS/iPadOS, Opera
+**Version number:**  6.0.0 <br>
+**Framework versions:** 5.14+ <br>
+**Author / maintainer:** Kineo <br>
+**Accessibility support:** WAI AA <br>
+**RTL support:** Yes <br>
+**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, IE11, Safari 14 for macOS/iOS/iPadOS, Opera <br>

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
         "url": "git://github.com/cgkineo/adapt-list.git"
     },
     "framework": ">=5.14",
-    "version": "5.1.1",
+    "version": "6.0.0",
     "homepage": "https://github.com/cgkineo/adapt-list",
     "issues": "https://github.com/cgkineo/adapt-list/issues",
     "component": "list",

--- a/example.json
+++ b/example.json
@@ -3,52 +3,48 @@
         "_parentId": "b-05",
         "_type": "component",
         "_component": "list",
-        "_comment": "Supported classes = 'align-items-vert-center'. Aligns either the step number or image centrally, on the vertical axis, with the content.",
         "_classes": "",
         "_layout": "full",
         "title": "List component",
         "displayTitle": "List component",
         "body": "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa.<br/><br/>Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.",
         "instruction": "Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim.",
+        "_columns": 0,
+        "_orderedList": false,
         "_animateList": false,
         "_percentInviewVertical": 70,
-        "_orderedList": false,
-        "_columns": 0,
+        "_itemHorizontalAlignment": "start",
+        "_bulletAlignment": "start",
         "_items": [
             {
                 "title": "Lorem ipsum dolor sit amet",
                 "body": "Lorem ipsum dolor sit amet, consectetuer adipiscing elit.",
-                "_imageSrc": "",
-                "alt": "",
-                "_classes": ""
+                "_classes": "",
+                "_graphic": {
+                    "src": "",
+                    "alt": "",
+                    "attribution": ""
+                }
             },
             {
                 "title": "Lorem ipsum dolor sit amet",
                 "body": "Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus.",
-                "_imageSrc": "",
-                "alt": "",
-                "_classes": ""
+                "_classes": "",
+                "_graphic": {
+                    "src": "",
+                    "alt": "",
+                    "attribution": ""
+                }
             },
             {
                 "title": "Lorem ipsum dolor sit amet",
                 "body": "Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim.",
-                "_imageSrc": "",
-                "alt": "",
-                "_classes": ""
-            },
-            {
-                "title": "Lorem ipsum dolor sit amet",
-                "body": "Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero.",
-                "_imageSrc": "",
-                "alt": "",
-                "_classes": ""
-            },
-            {
-                "title": "Lorem ipsum dolor sit amet",
-                "body": "Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem.",
-                "_imageSrc": "",
-                "alt": "",
-                "_classes": ""
+                "_classes": "",
+                "_graphic": {
+                    "src": "",
+                    "alt": "",
+                    "attribution": ""
+                }
             }
         ],
         "_pageLevelProgress": {

--- a/js/list-view.js
+++ b/js/list-view.js
@@ -15,10 +15,19 @@ class ListView extends ComponentView {
   postRender() {
     this.setReadyStatus();
     this.setupInviewCompletion('.component__widget');
+    this.contentAlignment();
 
     if (this.model.get('_animateList') && (!$('html').hasClass('a11y-no-animations'))) {
       this.$('.list__container').on('onscreen.animate', this.checkIfOnScreen.bind(this));
     }
+  }
+
+  contentAlignment() {
+    const _horizontalAlignment = this.model.get('_itemHorizontalAlignment');
+    const _bulletAlignment = this.model.get('_bulletAlignment');
+
+    if (_horizontalAlignment) this.$el.addClass(`item-justify-${_horizontalAlignment}`);
+    if (_bulletAlignment) this.$el.addClass(`bullet-align-${_bulletAlignment}`);
   }
 
   /**

--- a/less/list.less
+++ b/less/list.less
@@ -38,11 +38,11 @@
   &__image-container {
     align-items: flex-start;
     justify-content: center;
-    width: 80px;
+    width: 5rem;
   }
 
   &__image-container + &__content {
-    width: calc(~'100% - 80px');
+    width: calc(~'100% - 5rem');
   }
 
   // Ordered / unordered list bullet

--- a/less/list.less
+++ b/less/list.less
@@ -9,17 +9,17 @@
     content: counter(step-counter);
   }
 
-  // Vertically align image / bullet with item
-  // --------------------------------------------------
-  &.align-items-vert-center &-item__inner {
-    align-items: center;
-  }
-
   // Horizontally align items
   // --------------------------------------------------
-  &.align-items-hori-center &__container.has-columns {
-    justify-content: center;
-  }
+  &.item-justify-start &__container.has-columns { justify-content: flex-start; }
+  &.item-justify-center &__container.has-columns { justify-content: center; }
+  &.item-justify-end &__container.has-columns { justify-content: flex-end; }
+
+  // Vertically align image / bullet
+  // --------------------------------------------------
+  &.bullet-align-start &-item__inner { align-items: flex-start; }
+  &.bullet-align-center &-item__inner { align-items: center; }
+  &.bullet-align-end &-item__inner { align-items: flex-end; }
 }
 
 .list-item {

--- a/less/list.less
+++ b/less/list.less
@@ -26,11 +26,11 @@
   &__image-container {
     align-items: flex-start;
     justify-content: center;
-    width: 20%;
+    width: 96px;
   }
 
   &__image-container + &__content {
-    width: 80%;
+    width: calc(~'100% - 96px');
   }
 }
 
@@ -49,7 +49,7 @@
     right: -100%;
     opacity: 0;
     .transition(all .8s ease-in-out);
-    
+
     .dir-rtl & {
       right: inherit;
       left: -100%;
@@ -58,7 +58,7 @@
     &.is-animating {
       right: 0;
       opacity: 1;
-      
+
       .dir-rtl & {
         right: inherit;
         left: 0;

--- a/less/list.less
+++ b/less/list.less
@@ -8,6 +8,18 @@
   &__container.is-ordered-list &-item__bullet:before {
     content: counter(step-counter);
   }
+
+  // Vertically align image / bullet with item
+  // --------------------------------------------------
+  &.align-items-vert-center &-item__inner {
+    align-items: center;
+  }
+
+  // Horizontally align items
+  // --------------------------------------------------
+  &.align-items-hori-center &__container.has-columns {
+    justify-content: center;
+  }
 }
 
 .list-item {
@@ -26,11 +38,19 @@
   &__image-container {
     align-items: flex-start;
     justify-content: center;
-    width: 96px;
+    width: 80px;
   }
 
   &__image-container + &__content {
-    width: calc(~'100% - 96px');
+    width: calc(~'100% - 80px');
+  }
+
+  // Ordered / unordered list bullet
+  // --------------------------------------------------
+  &__bullet:before {
+    content: "";
+    height: @icon-size;
+    width: @icon-size;
   }
 }
 
@@ -68,40 +88,47 @@
 
   // Column layout
   // --------------------------------------------------
-  &__container.has-columns {
-    display: flex;
+  &__container.has-columns &-item.has-image &-item__inner {
     flex-wrap: wrap;
-    justify-content: center;
-    align-items: stretch;
-  }
-
-  &__container.has-columns &-item {
-    width: 100%;
-
-    @media (min-width: @device-width-small) {
-      width: 50%;
-    }
-  }
-
-  &__container.has-columns &-item__inner {
-    flex-direction: column;
-    margin: @item-margin;
   }
 
   &__container.has-columns &-item__image-container {
     width: 100%;
-    padding: inherit;
-    margin-bottom: @item-margin;
+    padding-right: inherit;
+    margin-bottom: @item-margin * 2;
   }
 
-  &__container.has-columns &-item__content {
+  &__container.has-columns &-item__image-container + &-item__content {
     width: 100%;
   }
 
-  // Vertically align image / number with item
-  // --------------------------------------------------
-  &.align-items-vert-center &-item__inner {
-    align-items: center;
+  @media (min-width: @device-width-medium) {
+    &__container.has-columns {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: stretch;
+    }
+
+    &__container.has-columns &-item__inner {
+      flex-direction: column;
+      margin: @item-margin;
+    }
+
+    &__container.has-columns &-item__image-container {
+      width: 100%;
+      padding: inherit;
+      margin-bottom: @item-margin * 2;
+    }
+
+    &__container.has-columns &-item__bullet {
+      margin-bottom: @item-margin * 2;
+      padding-left: inherit;
+      padding-right: inherit;
+    }
+
+    &__container.has-columns &-item__content {
+      width: 100%;
+    }
   }
 }
 
@@ -118,7 +145,11 @@
     margin-bottom: @item-title-margin;
   }
 
-  // List with image / bullet (ordered / unordered)
+  &__content {
+    width: 100%;
+  }
+
+  // List with image
   // --------------------------------------------------
   &__image-container {
     padding-right: @item-padding;
@@ -129,19 +160,14 @@
     }
   }
 
+  // Un/ordered layout
+  // --------------------------------------------------
   &__bullet {
     padding-left: @item-padding;
     padding-right: @item-padding;
   }
 
-  // Ordered / unordered list bullet
-  // --------------------------------------------------
   &__bullet:before {
-    content: "";
-    height: @icon-size * 2;
-    width: @icon-size * 2;
-    padding: @icon-size / 2;
-    .item-title;
     text-align: center;
     background-color: @item-color;
     color: @item-color-inverted;

--- a/less/list.less
+++ b/less/list.less
@@ -1,4 +1,30 @@
 .list {
+  // Column layout
+  // --------------------------------------------------
+  &__container.has-columns &-item.has-image &-item__inner {
+    flex-wrap: wrap;
+  }
+
+  &__container.has-columns &-item__image-container {
+    width: 100%;
+  }
+
+  &__container.has-columns &-item__image-container + &-item__content {
+    width: 100%;
+  }
+
+  @media (min-width: @device-width-medium) {
+    &__container.has-columns {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: stretch;
+    }
+
+    &__container.has-columns &-item__inner {
+      flex-direction: column;
+    }
+  }
+
   // Ordered list set up
   // --------------------------------------------------
   &__container.is-ordered-list &-item {
@@ -58,6 +84,25 @@
 // THEME
 // --------------------------------------------------
 .list {
+  // Column layout
+  // --------------------------------------------------
+  &__container.has-columns &-item__image-container {
+    padding-right: inherit;
+    margin-bottom: @item-margin * 2;
+  }
+
+  @media (min-width: @device-width-medium) {
+    &__container.has-columns &-item__inner {
+      margin: @item-margin;
+    }
+
+    &__container.has-columns &-item__bullet {
+      margin-bottom: @item-margin * 2;
+      padding-left: inherit;
+      padding-right: inherit;
+    }
+  }
+
   // Animated list set up
   // --------------------------------------------------
   &.is-animated-list &__widget {
@@ -74,60 +119,15 @@
       right: inherit;
       left: -100%;
     }
-
-    &.is-animating {
-      right: 0;
-      opacity: 1;
-
-      .dir-rtl & {
-        right: inherit;
-        left: 0;
-      }
-    }
   }
 
-  // Column layout
-  // --------------------------------------------------
-  &__container.has-columns &-item.has-image &-item__inner {
-    flex-wrap: wrap;
-  }
+  &.is-animated-list &-item.is-animating {
+    right: 0;
+    opacity: 1;
 
-  &__container.has-columns &-item__image-container {
-    width: 100%;
-    padding-right: inherit;
-    margin-bottom: @item-margin * 2;
-  }
-
-  &__container.has-columns &-item__image-container + &-item__content {
-    width: 100%;
-  }
-
-  @media (min-width: @device-width-medium) {
-    &__container.has-columns {
-      display: flex;
-      flex-wrap: wrap;
-      align-items: stretch;
-    }
-
-    &__container.has-columns &-item__inner {
-      flex-direction: column;
-      margin: @item-margin;
-    }
-
-    &__container.has-columns &-item__image-container {
-      width: 100%;
-      padding: inherit;
-      margin-bottom: @item-margin * 2;
-    }
-
-    &__container.has-columns &-item__bullet {
-      margin-bottom: @item-margin * 2;
-      padding-left: inherit;
-      padding-right: inherit;
-    }
-
-    &__container.has-columns &-item__content {
-      width: 100%;
+    .dir-rtl & {
+      right: inherit;
+      left: 0;
     }
   }
 }
@@ -160,7 +160,7 @@
     }
   }
 
-  // Un/ordered layout
+  // Ordered / unordered list bullet
   // --------------------------------------------------
   &__bullet {
     padding-left: @item-padding;

--- a/properties.schema
+++ b/properties.schema
@@ -73,7 +73,7 @@
       "default": "start",
       "inputType": {"type":"Select", "options":["start","center","end"]},
       "title": "Item horizontal alignment",
-      "help": "Find more info out <a href='https://github.com/cgkineo/adapt-list/tree/issue/46#_verticalAlignment' target='_blank'>here</a>"
+      "help": "Controls the horizontal alignment of the list items. This setting will only take affect if the `_columns` property has a value above `0`. Refer to the plugins readme for further info."
     },
     "_bulletAlignment": {
       "type": "string",
@@ -81,7 +81,7 @@
       "default": "start",
       "inputType": {"type":"Select", "options":["start","center","end"]},
       "title": "Image or bullet alignment",
-      "help": "Find more info out <a href='https://github.com/cgkineo/adapt-list/blob/issue/46/README.md#_verticalAlignment' target='_blank'>here</a>"
+      "help": "Controls the vertical alignment of the list item image or bullet alongside the text content. If the `_columns` property has a value above `0` then this properties alignment switches from vertical to horizontal. Refer to the plugins readme for further info."
     },
     "_items": {
       "type": "array",

--- a/properties.schema
+++ b/properties.schema
@@ -123,15 +123,15 @@
           },
           "_graphic": {
             "type": "object",
-            "required": true,
+            "required": false,
             "title": "List Item Graphic",
             "properties": {
               "src": {
                 "type": "string",
-                "required": true,
+                "required": false,
                 "default": "",
                 "inputType": "Asset:image",
-                "validators": ["required"],
+                "validators": [],
                 "help": "Image to be displayed in the list item."
               },
               "alt": {

--- a/properties.schema
+++ b/properties.schema
@@ -30,6 +30,24 @@
       "help": "This is the instruction text",
       "translatable": true
     },
+    "_columns": {
+      "type": "number",
+      "required": false,
+      "default": 0,
+      "title": "Columns",
+      "inputType": "Number",
+      "validators": ["number"],
+      "help": "Set the number of columns. If value is '0', component uses the default layout."
+    },
+    "_orderedList": {
+      "type": "boolean",
+      "required": false,
+      "title": "Ordered list",
+      "inputType": "Checkbox",
+      "validators": [],
+      "help": "Set items as ordered list",
+      "translatable": false
+    },
     "_animateList": {
       "type": "boolean",
       "required": false,
@@ -49,23 +67,21 @@
       "validators": ["number"],
       "help": "Controls what percentage of the list items height needs to be in the viewport in order for the items to animate"
     },
-    "_orderedList": {
-      "type": "boolean",
+    "_itemHorizontalAlignment": {
+      "type": "string",
       "required": false,
-      "title": "Ordered list",
-      "inputType": "Checkbox",
-      "validators": [],
-      "help": "Set items as ordered list",
-      "translatable": false
+      "default": "start",
+      "inputType": {"type":"Select", "options":["start","center","end"]},
+      "title": "Item horizontal alignment",
+      "help": "Find more info out <a href='https://github.com/cgkineo/adapt-list/tree/issue/46#_verticalAlignment' target='_blank'>here</a>"
     },
-    "_columns": {
-      "type": "number",
+    "_bulletAlignment": {
+      "type": "string",
       "required": false,
-      "default": 0,
-      "title": "Columns",
-      "inputType": "Number",
-      "validators": ["number"],
-      "help": "Set the number of columns. If value is '0', component uses the default layout."
+      "default": "start",
+      "inputType": {"type":"Select", "options":["start","center","end"]},
+      "title": "Image or bullet alignment",
+      "help": "Find more info out <a href='https://github.com/cgkineo/adapt-list/blob/issue/46/README.md#_verticalAlignment' target='_blank'>here</a>"
     },
     "_items": {
       "type": "array",
@@ -96,25 +112,6 @@
             "help": "Content area of the list item",
             "translatable": true
           },
-          "_imageSrc": {
-            "type": "string",
-            "required": false,
-            "default": "",
-            "title": "Item image",
-            "inputType": "Asset:image",
-            "validators": [],
-            "help": "Image for the list item bullet"
-          },
-          "alt": {
-            "type": "string",
-            "required": false,
-            "default": "",
-            "title": "Alternative text",
-            "inputType": "Text",
-            "validators": [],
-            "help": "A description of the image; required when it has meaning that must be conveyed to the learner. For 'decorative' images, leave this blank.",
-            "translatable": true
-          },
           "_classes": {
             "type": "string",
             "default": "",
@@ -123,6 +120,40 @@
             "validators": [],
             "title": "Classes",
             "help": "Used to style or manipulate the look and feel of this list item. These are predefined in the theme or added in Project Settings > Custom CSS/Less code."
+          },
+          "_graphic": {
+            "type": "object",
+            "required": true,
+            "title": "List Item Graphic",
+            "properties": {
+              "src": {
+                "type": "string",
+                "required": true,
+                "default": "",
+                "inputType": "Asset:image",
+                "validators": ["required"],
+                "help": "Image to be displayed in the list item."
+              },
+              "alt": {
+                "type": "string",
+                "required": false,
+                "default": "",
+                "title": "Alternative text",
+                "inputType": "Text",
+                "validators": [],
+                "help": "A description of the image; required when it has meaning that must be conveyed to the learner. For 'decorative' images, leave this blank.",
+                "translatable": true
+              },
+              "attribution": {
+                "type": "string",
+                "required": false,
+                "default": "",
+                "inputType": "Text",
+                "validators": [],
+                "help": "Text to be displayed as an attribution for the list item image.",
+                "translatable": true
+              }
+            }
           }
         }
       }

--- a/templates/list.jsx
+++ b/templates/list.jsx
@@ -27,6 +27,7 @@ export default function List({ _columns, _orderedList, _items, ...props }) {
               className={classes([
                 'list-item',
                 _isActive && 'is-animating',
+                _imageSrc && 'has-image',
                 _classes
               ])}
               role="listitem"
@@ -43,7 +44,7 @@ export default function List({ _columns, _orderedList, _items, ...props }) {
                 }
                 <div className="list-item__content">
                   {title &&
-                    <div 
+                    <div
                       className={classes([
                         'list-item__title',
                         body && 'has-margin'

--- a/templates/list.jsx
+++ b/templates/list.jsx
@@ -21,27 +21,27 @@ export default function List({ _columns, _orderedList, _items, ...props }) {
           ])}
           role="list"
         >
-          {_items.map(({ _isActive, _classes, _imageSrc, alt, title, body }, index) =>
+          {_items.map(({ _isActive, title, body, _classes, _graphic }, index) =>
             <div
               key={index}
               className={classes([
                 'list-item',
                 _isActive && 'is-animating',
-                _imageSrc && 'has-image',
+                _graphic.src && 'has-image',
                 _classes
               ])}
               role="listitem"
               style={(hasColumns && Adapt.device.screenSize === 'large' && { width: `${100 / _columns}%` }) || null}
             >
               <div className="list-item__inner">
-                {!_imageSrc ?
-                  <div className="list-item__bullet"></div> :
-                  <templates.image
-                    _src={_imageSrc}
-                    alt={alt}
-                    classNamePrefixes={[ 'list-item' ]}
+                {!_graphic.src ?
+                  <div className="list-item__bullet" aria-hidden="true"></div> :
+                  <templates.image {..._graphic}
+                    classNamePrefixes={['component-item', 'list-item']}
+                    attributionClassNamePrefixes={['component', 'list']}
                   />
                 }
+
                 <div className="list-item__content">
                   {title &&
                     <div
@@ -52,15 +52,21 @@ export default function List({ _columns, _orderedList, _items, ...props }) {
                       role="heading"
                       aria-level={a11y.ariaLevel('componentItem', itemAriaLevel)}
                     >
-                      <div className="list-item__title-inner">{html(compile(title))}</div>
+                      <div className="list-item__title-inner">
+                        {html(compile(title))}
+                      </div>
                     </div>
                   }
+
                   {body &&
                     <div className="list-item__body">
-                      <div className="list-item__body-inner">{html(compile(body))}</div>
+                      <div className="list-item__body-inner">
+                        {html(compile(body))}
+                      </div>
                     </div>
                   }
                 </div>
+
               </div>
             </div>
           )}


### PR DESCRIPTION
Fixes: #46 

### Fix
* Set up a standard visual approach
* Reduced fixed size of images
* Moved basic bullet sizing to 'structure' section
* Added item horizontal center custom class
* Moved item alignment classes to 'structure' section
* Column layout amends
* Added image of each layout in readme
