### PR TITLE
Fix: item bottom margin (fixes #54)

### DIFF
--- a/less/list.less
+++ b/less/list.less
@@ -24,6 +24,11 @@
       flex-direction: column;
     }
   }
+  
+  &__container.has-columns &-item,
+  &__container:not(.has-columns) &-item:not(:last-child) {
+    margin-bottom: @item-margin * 2;
+  }
 
   // Ordered list set up
   // --------------------------------------------------
@@ -133,10 +138,6 @@
 }
 
 .list-item {
-  &:not(:last-child) {
-    margin-bottom: @item-margin * 2;
-  }
-
   &__title {
     .item-title;
   }


### PR DESCRIPTION
- apply `margin-bottom` to all items for column layout
- apply `margin-bottom` to all, except last item, for default stacked layout

Fixes https://github.com/cgkineo/adapt-list/issues/54 