### PR TITLE
Fix: Remove version number from readme, add subheading to course settings (fixes #56)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ Optional text to be displayed as an [attribution](https://wiki.creativecommons.o
 No known limitations.
 
 ----------------------------
-**Version number:**  6.0.0 <br>
 **Framework versions:** 5.14+ <br>
 **Author / maintainer:** Kineo <br>
 **Accessibility support:** WAI AA <br>

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -15,6 +15,7 @@
             "_list": {
               "type": "object",
               "default": {},
+              "title": "List",
               "properties": {
                 "ariaRegion": {
                   "type": "string",


### PR DESCRIPTION
Fix #56 

- Removes the plugin version number from readme
- Adds a "List" subheading to the course settings in the AAT