### PR TITLE
Fix: Fix schema input type of bodyAfter (fixes #69)

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -87,7 +87,7 @@
       "type": "string",
       "required": false,
       "default": "",
-      "inputType": "Text",
+      "inputType": "TextArea",
       "validators": [],
       "title": "Body text after list items",
       "help": "This is the body text that will appear after the list items.",

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -92,7 +92,8 @@
           "default": "",
           "_adapt": {
             "translatable": true
-          }
+          },
+          "_backboneForms": "TextArea"
         },
         "_items": {
           "type": "array",


### PR DESCRIPTION
Fix #69 

### Fix
* Changes the input type of `bodyAfter` to TextArea