### PR TITLE
Fix: Reduce size of list bullet (fixes #66)

### DIFF
--- a/less/list.less
+++ b/less/list.less
@@ -97,7 +97,6 @@
     content: "";
     height: 0.65rem;
     width: 0.65rem;
-    line-height: @item-title-line-height;
   }
 }
 

--- a/less/list.less
+++ b/less/list.less
@@ -158,8 +158,8 @@
     .item-title;
   }
 
-  &.has-title.has-body &__title {
-    margin-bottom: @item-title-margin;
+  &__title + &__body {
+    margin-top: @item-title-margin;
   }
 
   &__content {

--- a/less/list.less
+++ b/less/list.less
@@ -84,10 +84,23 @@
 
   // Ordered / unordered list bullet
   // --------------------------------------------------
+  &__bullet {
+    align-items: center;
+    height: (@item-title-size * @item-title-line-height);
+  }
+
+  &:not(.has-title) &__bullet {
+    height: (@body-size * @body-line-height);
+  }
+
   &__bullet:before {
     content: "";
+    // height: (@item-title-size * @item-title-line-height);
+    // width: (@item-title-size * @item-title-line-height);
     height: 0.65rem;
     width: 0.65rem;
+    line-height: @item-title-line-height;
+    // line-height: (@item-title-size * @item-title-line-height);
   }
 }
 
@@ -148,7 +161,7 @@
     .item-title;
   }
 
-  &__title.has-margin {
+  &.has-title.has-body &__title {
     margin-bottom: @item-title-margin;
   }
 
@@ -179,6 +192,5 @@
     background-color: @item-color;
     color: @item-color-inverted;
     border-radius: 50%;
-    margin-top: 0.5rem;
   }
 }

--- a/less/list.less
+++ b/less/list.less
@@ -86,8 +86,8 @@
   // --------------------------------------------------
   &__bullet:before {
     content: "";
-    height: @icon-size;
-    width: @icon-size;
+    height: 0.65rem;
+    width: 0.65rem;
   }
 }
 
@@ -179,5 +179,6 @@
     background-color: @item-color;
     color: @item-color-inverted;
     border-radius: 50%;
+    margin-top: 0.5rem;
   }
 }

--- a/less/list.less
+++ b/less/list.less
@@ -95,8 +95,8 @@
 
   &__bullet:before {
     content: "";
-    height: 0.65rem;
-    width: 0.65rem;
+    height: 0.5rem;
+    width: 0.5rem;
   }
 }
 

--- a/less/list.less
+++ b/less/list.less
@@ -95,12 +95,9 @@
 
   &__bullet:before {
     content: "";
-    // height: (@item-title-size * @item-title-line-height);
-    // width: (@item-title-size * @item-title-line-height);
     height: 0.65rem;
     width: 0.65rem;
     line-height: @item-title-line-height;
-    // line-height: (@item-title-size * @item-title-line-height);
   }
 }
 

--- a/templates/list.jsx
+++ b/templates/list.jsx
@@ -30,6 +30,8 @@ export default function List({ _columns, _orderedList, _items, ...props }) {
                 'list-item',
                 _isActive && 'is-animating',
                 _graphic?.src && 'has-image',
+                title && 'has-title',
+                body && 'has-body',
                 _classes
               ])}
               role="listitem"
@@ -49,10 +51,7 @@ export default function List({ _columns, _orderedList, _items, ...props }) {
                 <div className="list-item__content">
                   {title &&
                     <div
-                      className={classes([
-                        'list-item__title',
-                        body && 'has-margin'
-                      ])}
+                      className="list-item__title"
                       role="heading"
                       aria-level={a11y.ariaLevel({ id: _id, level: 'componentItem', override: _ariaLevel ?? itemAriaLevel })}
                     >


### PR DESCRIPTION
Fixes #66 

### Fix
* Reduces the size of the list bullet and bases the vertical alignment on font variables
* Reworks item title margin when body is present. Removes `has-margin` class.

### Notes
* For the width and height, I'm using arbitrary values rather than tying them to an existing variable
* I added a top margin to the bullet to align it with the item title and body. Alternatively, we could tie this value to the item title / body font size, depending on which one (or both) exists. For example:

```
.list-item__bullet {
  align-items: center;
}

// If title exists
.list-item__bullet {
  height: @item-title-size;
}

// Or if title does not exist
.list-item__bullet {
  height: @item-body-size;
}
```
This might be overkill, but let me know what everyone thinks.