### PR TITLE
Fix: Moves bodyAfter field to match visual (fixes: Issue/76)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,6 @@ Controls the vertical alignment of the list item image or bullet alongside the t
 * `center`: Aligns the list item image or bullet to the center of the container vertically. If `_columns` is used then this setting aligns the list item image or bullet horizontally.
 * `end`: Aligns the list item image or bullet to the bottom of the container. If `_columns` is used then this setting aligns the list item image or bullet to the opposite side of the natural page direction. In a left-to-right course this is right by default.
 
-### bodyAfter (string):
-This is the body text that will appear after the list items.
-
 ### \_items (object):
 Multiple items may be created. Each item represents one list item for this component. It contains the following settings:
 
@@ -69,6 +66,9 @@ The alternative text for this image. Assign [alt text](https://github.com/adaptl
 
 ##### attribution (string):
 Optional text to be displayed as an [attribution](https://wiki.creativecommons.org/Best_practices_for_attribution). By default it is displayed below the image. Adjust positioning by modifying CSS. Text can contain HTML tags, e.g., `Copyright © 2015 by <b>Lukasz 'Severiaan' Grela</b>`
+
+### bodyAfter (string):
+This is the body text that will appear after the list items.
 
 ## Limitations
 

--- a/example.json
+++ b/example.json
@@ -8,7 +8,6 @@
         "title": "List component",
         "displayTitle": "List component",
         "body": "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa.<br/><br/>Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.",
-        "bodyAfter": "",
         "instruction": "",
         "_columns": 0,
         "_orderedList": false,
@@ -48,6 +47,7 @@
                 }
             }
         ],
+        "bodyAfter": "",
         "_pageLevelProgress": {
             "_isEnabled": true
         }

--- a/properties.schema
+++ b/properties.schema
@@ -83,16 +83,6 @@
       "title": "Image or bullet alignment",
       "help": "Controls the vertical alignment of the list item image or bullet alongside the text content. If the `_columns` property has a value above `0` then this properties alignment switches from vertical to horizontal. Refer to the plugins readme for further info."
     },
-    "bodyAfter": {
-      "type": "string",
-      "required": false,
-      "default": "",
-      "inputType": "TextArea",
-      "validators": [],
-      "title": "Body text after list items",
-      "help": "This is the body text that will appear after the list items.",
-      "translatable": true
-    },
     "_items": {
       "type": "array",
       "required": true,
@@ -167,6 +157,16 @@
           }
         }
       }
+    },
+    "bodyAfter": {
+      "type": "string",
+      "required": false,
+      "default": "",
+      "inputType": "TextArea",
+      "validators": [],
+      "title": "Body text after list items",
+      "help": "This is the body text that will appear after the list items.",
+      "translatable": true
     }
   }
 }

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -85,16 +85,6 @@
           ],
           "_backboneForms": "Select"
         },
-        "bodyAfter": {
-          "type": "string",
-          "title": "Body text after list items",
-          "description": "This is the body text that will appear after the list items.",
-          "default": "",
-          "_adapt": {
-            "translatable": true
-          },
-          "_backboneForms": "TextArea"
-        },
         "_items": {
           "type": "array",
           "title": "List Items",
@@ -167,6 +157,16 @@
               }
             }
           }
+        },
+        "bodyAfter": {
+          "type": "string",
+          "title": "Body text after list items",
+          "description": "This is the body text that will appear after the list items.",
+          "default": "",
+          "_adapt": {
+            "translatable": true
+          },
+          "_backboneForms": "TextArea"
         }
       }
     }


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* Moves bodyAfter field to after the component items to match onscreen visual. 
* Fixes #76 


