### PR TITLE
Fix: postpone `bodyAfter` display until list items have animated

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "git://github.com/cgkineo/adapt-list.git"
   },
-  "framework": ">=5.31.4",
+  "framework": ">=5.39.6",
   "version": "5.4.3",
   "homepage": "https://github.com/cgkineo/adapt-list",
   "issues": "https://github.com/cgkineo/adapt-list/issues",

--- a/js/ListView.js
+++ b/js/ListView.js
@@ -4,11 +4,7 @@ class ListView extends ComponentView {
 
   className() {
     let classes = super.className();
-    // don't animate when Visua11y 'no animations' is set
-    if (this.model.get('_animateList') && (!$('html').hasClass('a11y-no-animations'))) {
-      classes += ' is-animated-list';
-    }
-
+    if (this.isAnimatedList) classes += ' is-animated-list is-animating';
     return classes;
   }
 
@@ -17,7 +13,7 @@ class ListView extends ComponentView {
     this.setupInviewCompletion('.component__widget');
     this.contentAlignment();
 
-    if (this.model.get('_animateList') && (!$('html').hasClass('a11y-no-animations'))) {
+    if (this.isAnimatedList) {
       this.$('.list__container').on('onscreen.animate', this.checkIfOnScreen.bind(this));
     }
   }
@@ -45,8 +41,13 @@ class ListView extends ComponentView {
    * animates the list items in one-by-one
    */
   animateListItems() {
-    this.model.getChildren().forEach((listItem, index) => {
+    const items = this.model.getChildren();
+    const itemCount = items.length;
+    items.forEach((listItem, index) => {
       setTimeout(listItem.toggleActive.bind(listItem, true), 200 * index);
+      if (index !== (itemCount - 1)) return;
+      const $item = this.$('.list-item').eq(index);
+      $item.one('transitionend', () => this.$el.removeClass('is-animating'));
     });
   }
 
@@ -54,6 +55,11 @@ class ListView extends ComponentView {
     this.$('.list__container').off('onscreen.animate');
 
     super.remove();
+  }
+
+  get isAnimatedList() {
+    // don't animate when Visua11y 'no animations' is set
+    return this.model.get('_animateList') && (!$('html').hasClass('a11y-no-animations'));
   }
 };
 

--- a/js/ListView.js
+++ b/js/ListView.js
@@ -1,10 +1,14 @@
 import ComponentView from 'core/js/views/componentView';
+import { transitionsEnded } from 'core/js/transitions';
 
 class ListView extends ComponentView {
 
   className() {
     let classes = super.className();
-    if (this.isAnimatedList) classes += ' is-animated-list is-animating';
+    if (this.isAnimatedList) {
+      classes += ' is-animated-list';
+      if (!this._hasAnimated) classes += ' is-animating';
+    }
     return classes;
   }
 
@@ -44,10 +48,14 @@ class ListView extends ComponentView {
     const items = this.model.getChildren();
     const itemCount = items.length;
     items.forEach((listItem, index) => {
-      setTimeout(listItem.toggleActive.bind(listItem, true), 200 * index);
-      if (index !== (itemCount - 1)) return;
-      const $item = this.$('.list-item').eq(index);
-      $item.one('transitionend', () => this.$el.removeClass('is-animating'));
+      setTimeout(async () => {
+        listItem.toggleActive(true);
+        if (index !== (itemCount - 1)) return;
+        const $item = this.$('.list-item').eq(index);
+        await transitionsEnded($item);
+        this._hasAnimated = true;
+        this.$el.removeClass('is-animating');
+      }, 200 * index);
     });
   }
 

--- a/less/list.less
+++ b/less/list.less
@@ -57,6 +57,10 @@
   &__body-after {
     margin-top: @component-body-margin;
   }
+
+  &.is-animating &__body-after {
+    .u-visibility-hidden;
+  }
 }
 
 .list-item {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "git://github.com/cgkineo/adapt-list.git"
   },
-  "framework": ">=5.31.4",
+  "framework": ">=5.39.6",
   "version": "5.4.3",
   "homepage": "https://github.com/cgkineo/adapt-list",
   "issues": "https://github.com/cgkineo/adapt-list/issues",


### PR DESCRIPTION
Fixes #84.

### Fix
* Display `bodyAfter` once list items have animated. If no animation, it displays immediately as before.